### PR TITLE
Fixing content height

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -76,6 +76,8 @@ body {
       border-radius: 3px;
       box-shadow: 0px 0px 2px #333, inset 0px 0px 6px #666;
       margin-bottom: 20px;
+      max-height: 340px;
+      overflow: scroll;
     }
 
     // UL list of items


### PR DESCRIPTION
- Tong list could be annoying to scroll down, we set a max-height for the wrapper.
